### PR TITLE
Fix DJANGO_SETTINGS_MODULE in vagrant

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -46,7 +46,7 @@ su - vagrant -c "$PYTHON $PROJECT_DIR/manage.py clear_index --noinput && \
 # Add a couple of aliases to manage.py into .bashrc
 cat << EOF >> /home/vagrant/.bashrc
 export PYTHONPATH=$PROJECT_DIR
-export DJANGO_SETTINGS_MODULE=$PROJECT_NAME.settings.dev
+export DJANGO_SETTINGS_MODULE=wagtaildemo.settings.dev
 
 alias dj="django-admin"
 alias djrun="dj runserver 0.0.0.0:8000"


### PR DESCRIPTION
`vagrant/provision.sh` contains wrong value for `DJANGO_SETTINGS_MODULE`. As result `runserver` command fails with the following traceback:

```python
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/vagrant/.virtualenvs/oscarwagtaildemo/lib/python3.4/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/vagrant/.virtualenvs/oscarwagtaildemo/lib/python3.4/site-packages/django/core/management/__init__.py", line 303, in execute
    settings.INSTALLED_APPS
  File "/home/vagrant/.virtualenvs/oscarwagtaildemo/lib/python3.4/site-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/home/vagrant/.virtualenvs/oscarwagtaildemo/lib/python3.4/site-packages/django/conf/__init__.py", line 44, in _setup
    self._wrapped = Settings(settings_module)
  File "/home/vagrant/.virtualenvs/oscarwagtaildemo/lib/python3.4/site-packages/django/conf/__init__.py", line 92, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2212, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2212, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2224, in _find_and_load_unlocked
ImportError: No module named 'oscarwagtaildemo'
```